### PR TITLE
Fix actionlint workflow permission

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,9 @@
 name: actionlint
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/